### PR TITLE
Add mock covariate generator for exploratory runs

### DIFF
--- a/04_postprocess_plots.R
+++ b/04_postprocess_plots.R
@@ -115,7 +115,7 @@ summarise_group <- function(df, group_cols) {
     )
 }
 
-compute_age_curves <- function(draws, basis_grid, sex_draws, ages, label) {
+compute_age_draws <- function(draws, basis_grid, sex_draws) {
   alpha <- draws[, "alpha"]
   spline_draws <- extract_draws(draws, "^spline_coefs\\[")
   eta <- matrix(alpha, nrow = nrow(draws), ncol = nrow(basis_grid))
@@ -123,8 +123,11 @@ compute_age_curves <- function(draws, basis_grid, sex_draws, ages, label) {
     eta <- eta + t(basis_grid %*% t(spline_draws))
   }
   eta <- eta + matrix(sex_draws, nrow = nrow(draws), ncol = nrow(basis_grid))
-  prob <- logit_inv(eta)
-  stats <- summarise_matrix_draws(prob)
+  logit_inv(eta)
+}
+
+summarise_age_draws <- function(prob_matrix, ages, label) {
+  stats <- summarise_matrix_draws(prob_matrix)
   stats$age_group <- ages
   stats$sex <- label
   stats
@@ -200,10 +203,27 @@ run_postprocess <- function(posterior_file = file.path("ed_bayes_outputs", "mode
   readr::write_csv(time_summary, file.path(summaries_dir, "time_summary.csv"))
   sex_levels <- c("Female", "Male", "Mixed")
   observation_summary$sex <- factor(sex_levels[observation_summary$sex_idx], levels = sex_levels)
-  age_curves_f <- compute_age_curves(draws, basis_grid, draws[, "sex_beta[1]"], age_grid$age_group, "Female")
-  age_curves_m <- compute_age_curves(draws, basis_grid, draws[, "sex_beta[2]"], age_grid$age_group, "Male")
-  age_curves <- dplyr::bind_rows(age_curves_f, age_curves_m)
-  readr::write_csv(age_curves, file.path(summaries_dir, "age_curves.csv"))
+  female_draws <- compute_age_draws(draws, basis_grid, draws[, "sex_beta[1]"])
+  male_draws <- compute_age_draws(draws, basis_grid, draws[, "sex_beta[2]"])
+  age_curves_f <- summarise_age_draws(female_draws, age_grid$age_group, "Female")
+  age_curves_m <- summarise_age_draws(male_draws, age_grid$age_group, "Male")
+  female_fraction_vec <- dplyr::case_when(
+    metadata$sex_idx == 1 ~ 1,
+    metadata$sex_idx == 2 ~ 0,
+    TRUE ~ dplyr::coalesce(metadata$female_share, 0.5)
+  )
+  total_sample <- sum(metadata$sample_size, na.rm = TRUE)
+  female_total <- sum(metadata$sample_size * female_fraction_vec, na.rm = TRUE)
+  female_weight <- if (is.finite(total_sample) && total_sample > 0) female_total / total_sample else 0.5
+  if (!is.finite(female_weight) || female_weight < 0 || female_weight > 1) {
+    female_weight <- 0.5
+  }
+  combined_draws <- female_weight * female_draws + (1 - female_weight) * male_draws
+  age_curves_overall <- summarise_age_draws(combined_draws, age_grid$age_group, "Overall")
+  age_curve_summary <- dplyr::bind_rows(age_curves_f, age_curves_m, age_curves_overall)
+  readr::write_csv(age_curve_summary, file.path(summaries_dir, "age_group_summary.csv"))
+  readr::write_csv(dplyr::filter(age_curve_summary, sex %in% c("Female", "Male")),
+                   file.path(summaries_dir, "age_curves.csv"))
   sensitivity <- collect_sensitivity_results(observation_summary, output_dir)
   readr::write_csv(sensitivity, file.path(summaries_dir, "sensitivity_summary.csv"))
   # Plots
@@ -222,7 +242,8 @@ run_postprocess <- function(posterior_file = file.path("ed_bayes_outputs", "mode
     ggplot2::labs(title = "Time trend (2000-2025)", x = "Year", y = "Prevalence") +
     ggplot2::theme_minimal()
   ggplot2::ggsave(file.path(plots_dir, "time_trend.png"), national_plot, width = 8, height = 5, dpi = 120)
-  age_plot <- ggplot2::ggplot(age_curves, ggplot2::aes(x = age_group, y = mean, color = sex, group = sex)) +
+  age_curves_plot <- dplyr::filter(age_curve_summary, sex %in% c("Female", "Male"))
+  age_plot <- ggplot2::ggplot(age_curves_plot, ggplot2::aes(x = age_group, y = mean, color = sex, group = sex)) +
     ggplot2::geom_line() +
     ggplot2::geom_ribbon(ggplot2::aes(ymin = lower, ymax = upper, fill = sex), alpha = 0.2, colour = NA) +
     ggplot2::scale_y_continuous(labels = scales::percent_format(accuracy = 0.1)) +

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Rscript 03_model_nimble.R
 
 ### 04_postprocess_plots.R
 * Combines posterior draws and metadata to generate observation-level posterior summaries, province/national aggregates, time trends (2000–2025), age curves (10–80), sex comparisons, and sensitivity summaries.
-* Exports CSV summaries to `ed_bayes_outputs/summaries/` and ggplot visualisations (province bars, national trends, age curves, sex contrasts, sensitivity comparisons, convergence diagnostics) to `ed_bayes_outputs/plots/`.
+* Exports CSV summaries to `ed_bayes_outputs/summaries/` (including `age_group_summary.csv` with female, male, and combined age-specific prevalence) and ggplot visualisations (province bars, national trends, age curves, sex contrasts, sensitivity comparisons, convergence diagnostics) to `ed_bayes_outputs/plots/`.
 
 Run standalone (after modelling):
 
@@ -102,7 +102,15 @@ For a lightweight smoke test, use the files under `examples/`:
 
 1. Copy `examples/mock_data_long.csv` to a workbook containing a sheet named `Data_Long` (the cleaner expects Excel input). Any spreadsheet editor can import the CSV and save as `.xlsx`.
 2. Optionally supply `examples/mock_ageweights.csv` to `02_build_age_basis.R` via `age_weight_path`.
-3. Run the pipeline with:
+3. (Optional) Generate synthetic province-level covariates for SDI, total population, and age structure by running:
+
+```bash
+Rscript examples/generate_mock_covariates.R
+```
+
+This writes CSVs to `examples/mock_covariates/` (`province_sdi.csv`, `province_population_2020.csv`, `province_age_structure.csv`, and `province_extra_covariates.csv`). Point any exploratory model scripts to those paths when you need placeholder covariates.
+
+4. Run the pipeline with:
 
 ```bash
 Rscript ed_pipeline_nimble.R input_path=examples/mock_data_long.csv age_weight_path=examples/mock_ageweights.csv

--- a/examples/generate_mock_covariates.R
+++ b/examples/generate_mock_covariates.R
@@ -1,0 +1,81 @@
+#!/usr/bin/env Rscript
+suppressPackageStartupMessages({
+  if (!requireNamespace("readr", quietly = TRUE)) {
+    install.packages("readr", repos = "https://cloud.r-project.org", dependencies = TRUE)
+  }
+})
+
+set.seed(20240524)
+
+provinces <- c(
+  "北京", "天津", "河北", "山西", "内蒙古", "辽宁", "吉林", "黑龙江",
+  "上海", "江苏", "浙江", "安徽", "福建", "江西", "山东", "河南",
+  "湖北", "湖南", "广东", "广西", "海南", "重庆", "四川", "贵州",
+  "云南", "西藏", "陕西", "甘肃", "青海", "宁夏", "新疆"
+)
+
+n_prov <- length(provinces)
+
+make_dir <- function(path) {
+  dir.create(path, showWarnings = FALSE, recursive = TRUE)
+}
+
+cov_dir <- file.path("examples", "mock_covariates")
+make_dir(cov_dir)
+
+# Simulate SDI between 0.45 and 0.85 with mild spatial trend proxy via latitude rank
+rank_factor <- seq_len(n_prov)
+base_sdi <- 0.45 + (rank_factor - min(rank_factor)) / (max(rank_factor) - min(rank_factor)) * 0.35
+noise <- rnorm(n_prov, sd = 0.02)
+sdi <- pmin(pmax(base_sdi + noise, 0.35), 0.95)
+
+sdi_tbl <- data.frame(
+  province_std = provinces,
+  sdi = round(sdi, 3)
+)
+
+# Simulate total population (millions) with east-west gradient
+base_pop <- exp(rnorm(n_prov, mean = 2, sd = 0.6)) * 1e6
+# Upscale coastal provinces by factor
+coastal <- provinces %in% c("上海", "江苏", "浙江", "福建", "广东", "山东", "辽宁", "天津", "海南")
+base_pop[coastal] <- base_pop[coastal] * runif(sum(coastal), 1.2, 1.6)
+# Ensure Tibet, Qinghai smaller
+small <- provinces %in% c("西藏", "青海", "宁夏")
+base_pop[small] <- base_pop[small] * runif(sum(small), 0.3, 0.5)
+
+population <- round(base_pop)
+total_population <- sum(population)
+weight <- population / total_population
+
+# Age structure shares for 5-year groups (10-14 ... 80+) using normalized gamma draws
+groups <- c("10_14", "15_19", "20_24", "25_29", "30_34", "35_39",
+            "40_44", "45_49", "50_54", "55_59", "60_64", "65_69", "70_74", "75_79", "80_plus")
+
+age_matrix <- replicate(length(groups), rgamma(n_prov, shape = 2, rate = 1))
+age_shares <- age_matrix / rowSums(age_matrix)
+age_df <- as.data.frame(age_shares)
+colnames(age_df) <- paste0("share_", groups)
+age_df[] <- lapply(age_df, function(col) round(col, 4))
+
+pop_tbl <- data.frame(
+  province_std = provinces,
+  population = population,
+  weight = round(weight, 5)
+)
+pop_age_tbl <- cbind(pop_tbl["province_std"], age_df)
+
+# Household urban share + GDP per capita as extra optional covariates
+urban_share <- pmin(pmax(rbeta(n_prov, 5, 3), 0.2), 0.9)
+gdp_pc <- round(rlnorm(n_prov, meanlog = log(60000), sdlog = 0.35))
+extra_tbl <- data.frame(
+  province_std = provinces,
+  urban_share = round(urban_share, 3),
+  gdp_per_capita = gdp_pc
+)
+
+readr::write_csv(sdi_tbl, file.path(cov_dir, "province_sdi.csv"))
+readr::write_csv(pop_tbl, file.path(cov_dir, "province_population_2020.csv"))
+readr::write_csv(pop_age_tbl, file.path(cov_dir, "province_age_structure.csv"))
+readr::write_csv(extra_tbl, file.path(cov_dir, "province_extra_covariates.csv"))
+
+cat("Mock covariate files written to", cov_dir, "\n")


### PR DESCRIPTION
## Summary
- refactor age curve helpers to reuse posterior draws for multiple outputs
- derive female, male, and combined age-specific prevalence and export an aggregated age_group_summary.csv
- document the new summary artefact in the README post-processing description
- add a generator script that fabricates SDI, population, and age-structure covariates for exploratory runs and document how to use it in the README

## Testing
- not run (Rscript unavailable in execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68de670e9f6c8328aee81835d15f9fc1